### PR TITLE
shelf: restore leaping hare at each topic section label

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -738,6 +738,7 @@ p {
   margin-bottom: 1.25rem;
 }
 
+
 .section-label-name {
   font-family: var(--serif);
   font-size: 1.3rem;
@@ -6973,15 +6974,32 @@ body {
 }
 
 .section-label {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  display: flex;
+  align-items: center;
   gap: 0.7rem;
   margin: 0;
-  padding: 0.6rem 0.9rem;
+  padding: 0.5rem 0.9rem;
   background: var(--ink);
   color: var(--bg);
   border-bottom: 0;
-  align-items: center;
+}
+
+/* Leaping hare next to the topic name — engraved PNG, sits left of the
+   section title. Bar is dark in light mode (background: var(--ink)) so
+   the black PNG is inverted to cream; in dark mode the bar flips to cream,
+   the PNG stays black and reads naturally. */
+.section-label-mark {
+  width: 26px;
+  height: auto;
+  flex-shrink: 0;
+  display: block;
+  /* lift slightly: leaping hare's visual mass is above its geometric center
+     (legs extended down), so optical alignment with text needs a small nudge up */
+  transform: translateY(-4px);
+  filter: invert(1);
+}
+[data-theme="dark"] .section-label-mark {
+  filter: none;
 }
 
 .section-label-name {
@@ -6991,9 +7009,11 @@ body {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--bg);
+  margin: 0;
 }
 
 .section-label-count {
+  margin-left: auto;
   color: color-mix(in srgb, var(--bg) 70%, var(--ink) 30%);
 }
 

--- a/shelf.njk
+++ b/shelf.njk
@@ -209,6 +209,7 @@ pageClass: page-shelf
       {%- set listItems = bucket | where("shelf_list", true) %}
     <section id="{{ topic | slug }}" data-topic="{{ topic | slug }}" data-topic-name="{{ topic }}" data-topic-count="{{ bucket.length }}" class="topic-section">
       <header class="section-label">
+        <img class="section-label-mark" src="/img/rabbits/runner-lg.png" alt="" aria-hidden="true">
         <h2 class="section-label-name">{{ topic }}</h2>
         <span class="section-label-count" data-section-count>{{ bucket.length }}</span>
       </header>


### PR DESCRIPTION
## Summary
- Engraved hare ornament restored at each topic header (was dropped in May 6 field-note rebuild)
- .section-label converted from grid to flex so img + name + count flow inline
- Light/dark mode inversion logic correct: invert in light (dark bar), none in dark (cream bar)
- Optical alignment nudge of -4px so the hare sits centered with the title

## Test plan
- [ ] All 24 topics show a leaping hare next to the title
- [ ] Light mode: hare is cream on dark bar
- [ ] Dark mode: hare is black on cream bar
- [ ] Topic count anchored to right of bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)